### PR TITLE
[HC-02-AUTH] Add SQLite persistence and minimal auth manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 ## 0.0.1
 - Init: skeleton HeneriaCore (main class, plugin.yml, config.yml, CI).
+
+## 0.0.2
+- Add SQLite persistence layer and minimal AuthManager with register/login/logout commands.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     compileOnly("net.kyori:adventure-api:4.17.0")
     compileOnly("net.kyori:adventure-platform-bukkit:4.3.3")
     // ProtocolLib: activé seulement si -PwithPlib=true (voir plus bas)
+    implementation("org.xerial:sqlite-jdbc:3.45.1.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.1
+version=0.0.2

--- a/migrations/002_create_auth_schema.sql
+++ b/migrations/002_create_auth_schema.sql
@@ -1,0 +1,22 @@
+-- users
+CREATE TABLE IF NOT EXISTS users (
+  uuid TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  salt TEXT,
+  created_at INTEGER NOT NULL,
+  last_login INTEGER
+);
+
+-- sessions
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  uuid TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  FOREIGN KEY (uuid) REFERENCES users(uuid) ON DELETE CASCADE
+);
+
+-- index pour lookup
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_sessions_uuid ON sessions(uuid);

--- a/src/main/java/fr/heneriacore/HeneriaCore.java
+++ b/src/main/java/fr/heneriacore/HeneriaCore.java
@@ -1,16 +1,45 @@
 package fr.heneriacore;
 
+import fr.heneriacore.auth.AuthManager;
+import fr.heneriacore.auth.PasswordHasher;
+import fr.heneriacore.cmd.AuthCommand;
+import fr.heneriacore.db.SQLiteManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
+
 public final class HeneriaCore extends JavaPlugin {
+    private SQLiteManager sqlite;
+    private AuthManager authManager;
+
     @Override
     public void onEnable() {
-        getLogger().info("HeneriaCore v0.0.1 starting...");
-        // TODO: register services / listeners here (HC-02+)
+        saveDefaultConfig();
+        getLogger().info("HeneriaCore v" + getDescription().getVersion() + " starting...");
+        sqlite = new SQLiteManager();
+        try {
+            File dbFile = new File(getConfig().getString("auth.db", "data/heneria.db"));
+            sqlite.init(dbFile);
+        } catch (Exception e) {
+            getLogger().severe("Failed to init DB: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        PasswordHasher hasher = new PasswordHasher(getConfig().getString("auth.hash", "pbkdf2"));
+        long ttl = getConfig().getLong("auth.session-ttl-seconds", 86400L);
+        authManager = new AuthManager(this, sqlite, hasher, ttl);
+        AuthCommand cmd = new AuthCommand(this, authManager);
+        getCommand("heneria").setExecutor(cmd);
+        getCommand("heneria").setTabCompleter(cmd);
     }
 
     @Override
     public void onDisable() {
+        if (authManager != null) authManager.shutdown();
         getLogger().info("HeneriaCore stopped.");
+    }
+
+    public AuthManager getAuthManager() {
+        return authManager;
     }
 }

--- a/src/main/java/fr/heneriacore/auth/AuthManager.java
+++ b/src/main/java/fr/heneriacore/auth/AuthManager.java
@@ -1,0 +1,156 @@
+package fr.heneriacore.auth;
+
+import fr.heneriacore.db.SQLiteManager;
+import fr.heneriacore.event.AuthLogoutEvent;
+import fr.heneriacore.event.AuthPostLoginEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+import java.sql.*;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.security.SecureRandom;
+
+public class AuthManager {
+    private final Plugin plugin;
+    private final SQLiteManager db;
+    private final PasswordHasher hasher;
+    private final long sessionTtl;
+
+    private final Map<String, UUID> tokenToUuid = new ConcurrentHashMap<>();
+    private final Map<UUID, String> uuidToToken = new ConcurrentHashMap<>();
+
+    public AuthManager(Plugin plugin, SQLiteManager db, PasswordHasher hasher, long sessionTtl) {
+        this.plugin = plugin;
+        this.db = db;
+        this.hasher = hasher;
+        this.sessionTtl = sessionTtl;
+        loadActiveSessions();
+    }
+
+    private void loadActiveSessions() {
+        db.supplyAsync(conn -> {
+            long now = Instant.now().getEpochSecond();
+            try (PreparedStatement ps = conn.prepareStatement("SELECT token, uuid, expires_at FROM sessions")) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        long exp = rs.getLong("expires_at");
+                        String token = rs.getString("token");
+                        if (exp > now) {
+                            UUID uuid = UUID.fromString(rs.getString("uuid"));
+                            tokenToUuid.put(token, uuid);
+                            uuidToToken.put(uuid, token);
+                        } else {
+                            try (PreparedStatement del = conn.prepareStatement("DELETE FROM sessions WHERE token=?")) {
+                                del.setString(1, token);
+                                del.executeUpdate();
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        });
+    }
+
+    public CompletableFuture<Boolean> register(UUID uuid, String username, char[] password) {
+        return db.supplyAsync(conn -> {
+            try (PreparedStatement check = conn.prepareStatement("SELECT uuid FROM users WHERE uuid=? OR username=?")) {
+                check.setString(1, uuid.toString());
+                check.setString(2, username);
+                try (ResultSet rs = check.executeQuery()) {
+                    if (rs.next()) return false;
+                }
+            }
+            byte[] salt = PasswordHasher.generateSalt(16);
+            String hash = hasher.hash(password, salt);
+            Arrays.fill(password, '\0');
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO users(uuid, username, password_hash, salt, created_at) VALUES(?,?,?,?,?)")) {
+                ps.setString(1, uuid.toString());
+                ps.setString(2, username);
+                ps.setString(3, hash);
+                ps.setString(4, Base64.getEncoder().encodeToString(salt));
+                ps.setLong(5, Instant.now().getEpochSecond());
+                ps.executeUpdate();
+            }
+            return true;
+        });
+    }
+
+    public CompletableFuture<Optional<String>> login(UUID uuid, String username, char[] password) {
+        return db.supplyAsync(conn -> {
+            String stored = null;
+            try (PreparedStatement ps = conn.prepareStatement("SELECT password_hash FROM users WHERE uuid=?")) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) stored = rs.getString(1);
+                }
+            }
+            if (stored == null) return Optional.empty();
+            boolean ok = hasher.verify(password, stored);
+            Arrays.fill(password, '\0');
+            if (!ok) return Optional.empty();
+            String token = generateToken();
+            long now = Instant.now().getEpochSecond();
+            long exp = now + sessionTtl;
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO sessions(token, uuid, created_at, expires_at) VALUES(?,?,?,?)")) {
+                ps.setString(1, token);
+                ps.setString(2, uuid.toString());
+                ps.setLong(3, now);
+                ps.setLong(4, exp);
+                ps.executeUpdate();
+            }
+            tokenToUuid.put(token, uuid);
+            uuidToToken.put(uuid, token);
+            String finalToken = token;
+            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getPluginManager().callEvent(new AuthPostLoginEvent(uuid)));
+            return Optional.of(finalToken);
+        });
+    }
+
+    public CompletableFuture<Boolean> logout(String token) {
+        UUID uuid = tokenToUuid.remove(token);
+        if (uuid == null) return CompletableFuture.completedFuture(false);
+        uuidToToken.remove(uuid);
+        return db.supplyAsync(conn -> {
+            try (PreparedStatement ps = conn.prepareStatement("DELETE FROM sessions WHERE token=?")) {
+                ps.setString(1, token);
+                ps.executeUpdate();
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getPluginManager().callEvent(new AuthLogoutEvent(uuid)));
+            return true;
+        });
+    }
+
+    public Optional<UUID> getUuidByToken(String token) {
+        return Optional.ofNullable(tokenToUuid.get(token));
+    }
+
+    public Optional<String> getToken(UUID uuid) {
+        return Optional.ofNullable(uuidToToken.get(uuid));
+    }
+
+    public boolean isAuthenticated(UUID uuid) {
+        return uuidToToken.containsKey(uuid);
+    }
+
+    public void shutdown() {
+        db.close();
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/fr/heneriacore/auth/PasswordHasher.java
+++ b/src/main/java/fr/heneriacore/auth/PasswordHasher.java
@@ -1,0 +1,53 @@
+package fr.heneriacore.auth;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+import java.util.Arrays;
+
+public class PasswordHasher {
+    private final String algorithm;
+    private final int iterations = 65536;
+    private final int keyLength = 256;
+
+    public PasswordHasher(String algorithm) {
+        this.algorithm = algorithm.equalsIgnoreCase("argon2") ? "Argon2" : "PBKDF2WithHmacSHA256";
+    }
+
+    public String hash(char[] password, byte[] salt) {
+        try {
+            PBEKeySpec spec = new PBEKeySpec(password, salt, iterations, keyLength);
+            SecretKeyFactory skf = SecretKeyFactory.getInstance(this.algorithm);
+            byte[] hash = skf.generateSecret(spec).getEncoded();
+            Arrays.fill(password, '\0');
+            return iterations + ":" + Base64.getEncoder().encodeToString(salt) + ":" + Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalStateException("Hashing failure", e);
+        }
+    }
+
+    public boolean verify(char[] password, String storedHash) {
+        try {
+            String[] parts = storedHash.split(":");
+            int iters = Integer.parseInt(parts[0]);
+            byte[] salt = Base64.getDecoder().decode(parts[1]);
+            byte[] hash = Base64.getDecoder().decode(parts[2]);
+            PBEKeySpec spec = new PBEKeySpec(password, salt, iters, hash.length * 8);
+            SecretKeyFactory skf = SecretKeyFactory.getInstance(this.algorithm);
+            byte[] test = skf.generateSecret(spec).getEncoded();
+            Arrays.fill(password, '\0');
+            return Arrays.equals(hash, test);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            return false;
+        }
+    }
+
+    public static byte[] generateSalt(int len) {
+        byte[] salt = new byte[len];
+        new SecureRandom().nextBytes(salt);
+        return salt;
+    }
+}

--- a/src/main/java/fr/heneriacore/cmd/AuthCommand.java
+++ b/src/main/java/fr/heneriacore/cmd/AuthCommand.java
@@ -1,0 +1,105 @@
+package fr.heneriacore.cmd;
+
+import fr.heneriacore.auth.AuthManager;
+import fr.heneriacore.event.AuthPreLoginEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AuthCommand implements CommandExecutor, TabCompleter {
+    private final Plugin plugin;
+    private final AuthManager authManager;
+
+    public AuthCommand(Plugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players");
+            return true;
+        }
+        if (args.length == 0) {
+            player.sendMessage("/heneria <register|login|logout>");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "register" -> {
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /heneria register <password>");
+                    return true;
+                }
+                char[] pass = args[1].toCharArray();
+                authManager.register(player.getUniqueId(), player.getName(), pass)
+                        .thenAccept(res -> Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (res) {
+                                player.sendMessage("Registered.");
+                                if (plugin.getConfig().getBoolean("auth.autoLoginAfterRegister", true)) {
+                                    login(player, pass);
+                                }
+                            } else {
+                                player.sendMessage("Already registered.");
+                            }
+                        }));
+                return true;
+            }
+            case "login" -> {
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /heneria login <password>");
+                    return true;
+                }
+                char[] pass = args[1].toCharArray();
+                AuthPreLoginEvent pre = new AuthPreLoginEvent(player);
+                Bukkit.getPluginManager().callEvent(pre);
+                if (pre.isCancelled()) {
+                    player.sendMessage("Login cancelled.");
+                    return true;
+                }
+                login(player, pass);
+                return true;
+            }
+            case "logout" -> {
+                authManager.getToken(player.getUniqueId()).ifPresentOrElse(token -> {
+                    authManager.logout(token).thenAccept(res -> Bukkit.getScheduler().runTask(plugin, () -> {
+                        if (res) player.sendMessage("Logged out.");
+                        else player.sendMessage("Not logged in.");
+                    }));
+                }, () -> player.sendMessage("Not logged in."));
+                return true;
+            }
+            default -> {
+                player.sendMessage("/heneria <register|login|logout>");
+                return true;
+            }
+        }
+    }
+
+    private void login(Player player, char[] pass) {
+        authManager.login(player.getUniqueId(), player.getName(), pass)
+                .thenAccept(opt -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    if (opt.isPresent()) {
+                        player.sendMessage("Login success.");
+                    } else {
+                        player.sendMessage("Login failed.");
+                    }
+                }));
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return Arrays.asList("register", "login", "logout");
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/fr/heneriacore/db/SQLiteManager.java
+++ b/src/main/java/fr/heneriacore/db/SQLiteManager.java
@@ -1,0 +1,60 @@
+package fr.heneriacore.db;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.*;
+
+public class SQLiteManager {
+    @FunctionalInterface
+    public interface DBTask<T> {
+        T execute(Connection connection) throws SQLException;
+    }
+
+    private Connection connection;
+    private ExecutorService executor;
+
+    public void init(File dbFile) throws SQLException, IOException {
+        if (executor != null) return;
+        dbFile.getParentFile().mkdirs();
+        this.connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+        this.executor = Executors.newFixedThreadPool(2);
+        runMigrations();
+    }
+
+    private void runMigrations() throws IOException, SQLException {
+        File dir = new File("migrations");
+        if (!dir.exists()) return;
+        File[] files = dir.listFiles((d, name) -> name.endsWith(".sql"));
+        if (files == null) return;
+        Arrays.sort(files, Comparator.comparing(File::getName));
+        try (Statement st = connection.createStatement()) {
+            for (File f : files) {
+                String sql = Files.readString(f.toPath());
+                st.execute(sql);
+            }
+        }
+    }
+
+    public <T> CompletableFuture<T> supplyAsync(DBTask<T> task) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return task.execute(connection);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, executor);
+    }
+
+    public void close() {
+        if (executor != null) {
+            executor.shutdown();
+        }
+        if (connection != null) {
+            try { connection.close(); } catch (SQLException ignored) {}
+        }
+    }
+}

--- a/src/main/java/fr/heneriacore/event/AuthLogoutEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthLogoutEvent.java
@@ -1,0 +1,28 @@
+package fr.heneriacore.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class AuthLogoutEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final UUID uuid;
+
+    public AuthLogoutEvent(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/fr/heneriacore/event/AuthPostLoginEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthPostLoginEvent.java
@@ -1,0 +1,28 @@
+package fr.heneriacore.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class AuthPostLoginEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final UUID uuid;
+
+    public AuthPostLoginEvent(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/fr/heneriacore/event/AuthPreLoginEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthPreLoginEvent.java
@@ -1,0 +1,39 @@
+package fr.heneriacore.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AuthPreLoginEvent extends Event implements Cancellable {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Player player;
+    private boolean cancelled;
+
+    public AuthPreLoginEvent(Player player) {
+        this.player = player;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,5 +7,12 @@ premium:
     rpm: 120
 auth:
   db: "data/heneria.db"
+  hash: "pbkdf2"
+  salt-length: 16
+  session-ttl-seconds: 86400
+  autoLoginAfterRegister: true
+  maxFailedAttempts: 5
+  lockDurationSeconds: 300
+  executor-threads: 2
 skin:
   apply-on-login: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,19 @@
 name: HeneriaCore
 main: fr.heneriacore.HeneriaCore
-version: "0.0.1"
+version: "0.0.2"
 api-version: "1.21"
 description: "HeneriaCore - monolithic plugin (premium auth + auth-local + skins). Skeleton init."
 authors: ["OpenAI"]
 softdepend: []   # ajouter ProtocolLib plus tard en softdepend si nécessaire
+commands:
+  heneria:
+    description: Heneria auth commands
+    usage: /heneria <register|login|logout>
+    permission: heneria.auth
+permissions:
+  heneria.auth:
+    description: Access to basic auth commands
+    default: true
+  heneria.auth.admin:
+    description: Manage other players auth
+    default: op


### PR DESCRIPTION
## Summary
- add SQLiteManager for migrations and async database operations
- implement PasswordHasher and AuthManager with session handling
- introduce /heneria register|login|logout commands and related events
- update config and bump version to 0.0.2

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_689e0e55dc0c832480771e7feccc8332