### PR TITLE
[HC-02-AUTH] Implement SQLite auth layer, commands, and CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,12 @@ jobs:
           java-version: '21'
 
       - name: Set up Gradle
-        uses: gradle/setup-gradle@v3
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: '8.14.3'
+
+      - name: Show gradle version
+        run: gradle --version
 
       - name: Build
         run: gradle clean build --no-daemon -Dorg.gradle.jvmargs="-Xmx2g"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
 ## 0.0.1
 - Init: skeleton HeneriaCore (main class, plugin.yml, config.yml, CI).
+
+## 0.0.2
+- Add SQLite database layer and AuthManager with sessions.
+- Implement PBKDF2 password hashing and auth commands.
+- Fix CI to use gradle/gradle-build-action@v3.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     compileOnly("net.kyori:adventure-platform-bukkit:4.3.3")
     // ProtocolLib: activé seulement si -PwithPlib=true (voir plus bas)
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    implementation("org.xerial:sqlite-jdbc:3.46.0.0")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.1
+version=0.0.2

--- a/migrations/002_create_auth_schema.sql
+++ b/migrations/002_create_auth_schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS users (
+  uuid TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  salt TEXT,
+  created_at INTEGER NOT NULL,
+  last_login INTEGER
+);
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  uuid TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  FOREIGN KEY (uuid) REFERENCES users(uuid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_sessions_uuid ON sessions(uuid);

--- a/src/main/java/fr/heneriacore/HeneriaCore.java
+++ b/src/main/java/fr/heneriacore/HeneriaCore.java
@@ -1,16 +1,43 @@
 package fr.heneriacore;
 
+import fr.heneriacore.auth.AuthManager;
+import fr.heneriacore.auth.PasswordHasher;
+import fr.heneriacore.db.SQLiteManager;
+import fr.heneriacore.cmd.AuthCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
+
 public final class HeneriaCore extends JavaPlugin {
+    private SQLiteManager sqliteManager;
+    private AuthManager authManager;
+
     @Override
     public void onEnable() {
-        getLogger().info("HeneriaCore v0.0.1 starting...");
-        // TODO: register services / listeners here (HC-02+)
+        saveDefaultConfig();
+        getLogger().info("HeneriaCore v" + getDescription().getVersion() + " starting...");
+        int threads = getConfig().getInt("auth.executor-threads", 2);
+        sqliteManager = new SQLiteManager(threads);
+        File dbFile = new File(getDataFolder(), getConfig().getString("auth.db", "data/heneria.db"));
+        sqliteManager.init(dbFile);
+        PasswordHasher hasher = new PasswordHasher();
+        long ttl = getConfig().getLong("auth.session-ttl-seconds", 86400L);
+        authManager = new AuthManager(this, sqliteManager, hasher, ttl);
+
+        AuthCommand authCmd = new AuthCommand(this);
+        getCommand("heneria").setExecutor(authCmd);
+        getCommand("heneria").setTabCompleter(authCmd);
     }
 
     @Override
     public void onDisable() {
+        if (authManager != null) {
+            authManager.shutdown();
+        }
         getLogger().info("HeneriaCore stopped.");
+    }
+
+    public AuthManager getAuthManager() {
+        return authManager;
     }
 }

--- a/src/main/java/fr/heneriacore/auth/AuthManager.java
+++ b/src/main/java/fr/heneriacore/auth/AuthManager.java
@@ -1,0 +1,167 @@
+package fr.heneriacore.auth;
+
+import fr.heneriacore.db.SQLiteManager;
+import fr.heneriacore.event.AuthLogoutEvent;
+import fr.heneriacore.event.AuthPostLoginEvent;
+import fr.heneriacore.event.AuthPreLoginEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AuthManager {
+    private final Plugin plugin;
+    private final SQLiteManager db;
+    private final PasswordHasher hasher;
+    private final long sessionTtlMillis;
+    private final Map<String, UUID> tokenToUuid = new ConcurrentHashMap<>();
+    private final Map<UUID, String> uuidToToken = new ConcurrentHashMap<>();
+    private final java.security.SecureRandom random = new java.security.SecureRandom();
+
+    public AuthManager(Plugin plugin, SQLiteManager db, PasswordHasher hasher, long sessionTtlSeconds) {
+        this.plugin = plugin;
+        this.db = db;
+        this.hasher = hasher;
+        this.sessionTtlMillis = sessionTtlSeconds * 1000L;
+    }
+
+    public CompletableFuture<Boolean> register(UUID uuid, String username, char[] password) {
+        return db.supplyAsync(conn -> {
+            String existsSql = "SELECT 1 FROM users WHERE uuid = ? OR username = ?";
+            try (var ps = conn.prepareStatement(existsSql)) {
+                ps.setString(1, uuid.toString());
+                ps.setString(2, username);
+                try (var rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return false;
+                    }
+                }
+            }
+            byte[] salt = new byte[16];
+            random.nextBytes(salt);
+            String hash = hasher.hash(password, salt);
+            String stored = Base64.getEncoder().encodeToString(salt) + ":" + hash;
+            java.util.Arrays.fill(password, '\0');
+            String insertSql = "INSERT INTO users(uuid, username, password_hash, salt, created_at) VALUES(?,?,?,?,?)";
+            try (var ps = conn.prepareStatement(insertSql)) {
+                ps.setString(1, uuid.toString());
+                ps.setString(2, username);
+                ps.setString(3, stored);
+                ps.setString(4, Base64.getEncoder().encodeToString(salt));
+                ps.setLong(5, System.currentTimeMillis());
+                ps.executeUpdate();
+                return true;
+            }
+        });
+    }
+
+    public CompletableFuture<Optional<String>> login(UUID uuid, String username, char[] password) {
+        Bukkit.getPluginManager().callEvent(new AuthPreLoginEvent(uuid, username));
+        return db.supplyAsync(conn -> {
+            String select = "SELECT password_hash FROM users WHERE uuid = ? OR username = ?";
+            try (var ps = conn.prepareStatement(select)) {
+                ps.setString(1, uuid.toString());
+                ps.setString(2, username);
+                try (var rs = ps.executeQuery()) {
+                    if (!rs.next()) {
+                        return Optional.<String>empty();
+                    }
+                    String stored = rs.getString("password_hash");
+                    if (!hasher.verify(password, stored)) {
+                        return Optional.<String>empty();
+                    }
+                }
+            }
+            java.util.Arrays.fill(password, '\0');
+            String token = generateToken();
+            long now = System.currentTimeMillis();
+            long expires = now + sessionTtlMillis;
+            String insert = "INSERT INTO sessions(token, uuid, created_at, expires_at) VALUES(?,?,?,?)";
+            try (var ps = conn.prepareStatement(insert)) {
+                ps.setString(1, token);
+                ps.setString(2, uuid.toString());
+                ps.setLong(3, now);
+                ps.setLong(4, expires);
+                ps.executeUpdate();
+            }
+            tokenToUuid.put(token, uuid);
+            uuidToToken.put(uuid, token);
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    Bukkit.getPluginManager().callEvent(new AuthPostLoginEvent(uuid, username, token)));
+            return Optional.of(token);
+        });
+    }
+
+    public CompletableFuture<Boolean> logout(String token) {
+        return db.supplyAsync(conn -> {
+            String delete = "DELETE FROM sessions WHERE token = ?";
+            try (var ps = conn.prepareStatement(delete)) {
+                ps.setString(1, token);
+                int updated = ps.executeUpdate();
+                UUID u = tokenToUuid.remove(token);
+                if (u != null) {
+                    uuidToToken.remove(u);
+                    UUID uuidFinal = u;
+                    Bukkit.getScheduler().runTask(plugin, () ->
+                            Bukkit.getPluginManager().callEvent(new AuthLogoutEvent(uuidFinal, token)));
+                }
+                return updated > 0;
+            }
+        });
+    }
+
+    public Optional<UUID> getUuidByToken(String token) {
+        UUID cached = tokenToUuid.get(token);
+        if (cached != null) return Optional.of(cached);
+        try {
+            return db.supplyAsync(conn -> {
+                String sql = "SELECT uuid, expires_at FROM sessions WHERE token = ?";
+                try (var ps = conn.prepareStatement(sql)) {
+                    ps.setString(1, token);
+                    try (var rs = ps.executeQuery()) {
+                        if (rs.next()) {
+                            long expires = rs.getLong("expires_at");
+                            if (expires < System.currentTimeMillis()) {
+                                try (var del = conn.prepareStatement("DELETE FROM sessions WHERE token = ?")) {
+                                    del.setString(1, token);
+                                    del.executeUpdate();
+                                }
+                                return Optional.<UUID>empty();
+                            }
+                            UUID u = UUID.fromString(rs.getString("uuid"));
+                            tokenToUuid.put(token, u);
+                            uuidToToken.put(u, token);
+                            return Optional.of(u);
+                        }
+                        return Optional.<UUID>empty();
+                    }
+                }
+            }).join();
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public boolean isAuthenticated(UUID uuid) {
+        return uuidToToken.containsKey(uuid);
+    }
+
+    public Optional<String> getToken(UUID uuid) {
+        return Optional.ofNullable(uuidToToken.get(uuid));
+    }
+
+    public void shutdown() {
+        db.close();
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[16];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/java/fr/heneriacore/auth/PasswordHasher.java
+++ b/src/main/java/fr/heneriacore/auth/PasswordHasher.java
@@ -1,0 +1,36 @@
+package fr.heneriacore.auth;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class PasswordHasher {
+    private static final String ALGO = "PBKDF2WithHmacSHA256";
+    private static final int ITERATIONS = 65536;
+    private static final int KEY_LENGTH = 256;
+
+    public String hash(char[] password, byte[] salt) {
+        try {
+            PBEKeySpec spec = new PBEKeySpec(password, salt, ITERATIONS, KEY_LENGTH);
+            SecretKeyFactory skf = SecretKeyFactory.getInstance(ALGO);
+            byte[] hash = skf.generateSecret(spec).getEncoded();
+            Arrays.fill(password, '\0');
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Hashing error", e);
+        }
+    }
+
+    public boolean verify(char[] password, String storedHash) {
+        String[] parts = storedHash.split(":", 2);
+        if (parts.length != 2) return false;
+        byte[] salt = Base64.getDecoder().decode(parts[0]);
+        String calculated = hash(password, salt);
+        Arrays.fill(password, '\0');
+        return MessageDigest.isEqual(Base64.getDecoder().decode(parts[1]), Base64.getDecoder().decode(calculated));
+    }
+}

--- a/src/main/java/fr/heneriacore/cmd/AuthCommand.java
+++ b/src/main/java/fr/heneriacore/cmd/AuthCommand.java
@@ -1,0 +1,97 @@
+package fr.heneriacore.cmd;
+
+import fr.heneriacore.HeneriaCore;
+import fr.heneriacore.auth.AuthManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class AuthCommand implements CommandExecutor, TabCompleter {
+    private final HeneriaCore plugin;
+    private final AuthManager auth;
+
+    public AuthCommand(HeneriaCore plugin) {
+        this.plugin = plugin;
+        this.auth = plugin.getAuthManager();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Players only");
+            return true;
+        }
+        if (args.length < 1) {
+            player.sendMessage("Usage: /" + label + " register|login|logout");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "register" -> {
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /" + label + " register <password>");
+                    return true;
+                }
+                char[] pw = args[1].toCharArray();
+                auth.register(player.getUniqueId(), player.getName(), pw).thenAccept(success ->
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (success) {
+                                player.sendMessage("Registered.");
+                                if (plugin.getConfig().getBoolean("auth.autoLoginAfterRegister", true)) {
+                                    auth.login(player.getUniqueId(), player.getName(), args[1].toCharArray());
+                                }
+                            } else {
+                                player.sendMessage("Already registered.");
+                            }
+                        }));
+            }
+            case "login" -> {
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /" + label + " login <password>");
+                    return true;
+                }
+                auth.login(player.getUniqueId(), player.getName(), args[1].toCharArray()).thenAccept(opt ->
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (opt.isPresent()) {
+                                player.sendMessage("Logged in.");
+                            } else {
+                                player.sendMessage("Invalid credentials.");
+                            }
+                        }));
+            }
+            case "logout" -> {
+                Optional<String> token = auth.getToken(player.getUniqueId());
+                if (token.isEmpty()) {
+                    player.sendMessage("Not logged in.");
+                    return true;
+                }
+                auth.logout(token.get()).thenAccept(res ->
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (res) {
+                                player.sendMessage("Logged out.");
+                            } else {
+                                player.sendMessage("Logout failed.");
+                            }
+                        }));
+            }
+            default -> player.sendMessage("Usage: /" + label + " register|login|logout");
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return Arrays.asList("register", "login", "logout");
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/fr/heneriacore/db/DBTask.java
+++ b/src/main/java/fr/heneriacore/db/DBTask.java
@@ -1,0 +1,9 @@
+package fr.heneriacore.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface DBTask<T> {
+    T execute(Connection connection) throws SQLException;
+}

--- a/src/main/java/fr/heneriacore/db/SQLiteManager.java
+++ b/src/main/java/fr/heneriacore/db/SQLiteManager.java
@@ -1,0 +1,73 @@
+package fr.heneriacore.db;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SQLiteManager {
+    private final ExecutorService executor;
+    private String jdbcUrl;
+
+    public SQLiteManager(int threads) {
+        this.executor = Executors.newFixedThreadPool(threads);
+    }
+
+    public void init(File dbFile) {
+        try {
+            if (dbFile.getParentFile() != null && !dbFile.getParentFile().exists()) {
+                dbFile.getParentFile().mkdirs();
+            }
+            this.jdbcUrl = "jdbc:sqlite:" + dbFile.getAbsolutePath();
+            runMigrations();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to init SQLite database", e);
+        }
+    }
+
+    private void runMigrations() throws IOException {
+        Path migrationsDir = Path.of("migrations");
+        if (!Files.exists(migrationsDir)) return;
+        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+            Files.list(migrationsDir)
+                    .filter(p -> p.toString().endsWith(".sql"))
+                    .sorted(Comparator.naturalOrder())
+                    .forEach(p -> {
+                        try {
+                            String sql = Files.readString(p, StandardCharsets.UTF_8);
+                            try (Statement stmt = conn.createStatement()) {
+                                stmt.executeUpdate(sql);
+                            }
+                        } catch (IOException | SQLException e) {
+                            throw new RuntimeException("Migration failed: " + p, e);
+                        }
+                    });
+        } catch (SQLException e) {
+            throw new RuntimeException("Cannot run migrations", e);
+        }
+    }
+
+    public <T> CompletableFuture<T> supplyAsync(DBTask<T> task) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+                return task.execute(conn);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, executor);
+    }
+
+    public void close() {
+        executor.shutdownNow();
+    }
+}

--- a/src/main/java/fr/heneriacore/event/AuthLogoutEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthLogoutEvent.java
@@ -1,0 +1,24 @@
+package fr.heneriacore.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class AuthLogoutEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final UUID uuid;
+    private final String token;
+
+    public AuthLogoutEvent(UUID uuid, String token) {
+        this.uuid = uuid;
+        this.token = token;
+    }
+
+    public UUID getUuid() { return uuid; }
+    public String getToken() { return token; }
+
+    @Override
+    public HandlerList getHandlers() { return HANDLERS; }
+    public static HandlerList getHandlerList() { return HANDLERS; }
+}

--- a/src/main/java/fr/heneriacore/event/AuthPostLoginEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthPostLoginEvent.java
@@ -1,0 +1,27 @@
+package fr.heneriacore.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class AuthPostLoginEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final UUID uuid;
+    private final String username;
+    private final String token;
+
+    public AuthPostLoginEvent(UUID uuid, String username, String token) {
+        this.uuid = uuid;
+        this.username = username;
+        this.token = token;
+    }
+
+    public UUID getUuid() { return uuid; }
+    public String getUsername() { return username; }
+    public String getToken() { return token; }
+
+    @Override
+    public HandlerList getHandlers() { return HANDLERS; }
+    public static HandlerList getHandlerList() { return HANDLERS; }
+}

--- a/src/main/java/fr/heneriacore/event/AuthPreLoginEvent.java
+++ b/src/main/java/fr/heneriacore/event/AuthPreLoginEvent.java
@@ -1,0 +1,24 @@
+package fr.heneriacore.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class AuthPreLoginEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final UUID uuid;
+    private final String username;
+
+    public AuthPreLoginEvent(UUID uuid, String username) {
+        this.uuid = uuid;
+        this.username = username;
+    }
+
+    public UUID getUuid() { return uuid; }
+    public String getUsername() { return username; }
+
+    @Override
+    public HandlerList getHandlers() { return HANDLERS; }
+    public static HandlerList getHandlerList() { return HANDLERS; }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,5 +7,12 @@ premium:
     rpm: 120
 auth:
   db: "data/heneria.db"
+  hash: "pbkdf2"
+  salt-length: 16
+  session-ttl-seconds: 86400
+  autoLoginAfterRegister: true
+  maxFailedAttempts: 5
+  lockDurationSeconds: 300
+  executor-threads: 2
 skin:
   apply-on-login: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,19 @@
 name: HeneriaCore
 main: fr.heneriacore.HeneriaCore
-version: "0.0.1"
+version: "0.0.2"
 api-version: "1.21"
 description: "HeneriaCore - monolithic plugin (premium auth + auth-local + skins). Skeleton init."
 authors: ["OpenAI"]
 softdepend: []   # ajouter ProtocolLib plus tard en softdepend si nécessaire
+commands:
+  heneria:
+    description: "Authentication commands"
+    usage: "/heneria <register|login|logout>"
+    permission: heneria.auth
+permissions:
+  heneria.auth:
+    description: "Allow use of auth commands"
+    default: true
+  heneria.auth.admin:
+    description: "Admin auth permissions"
+    default: op


### PR DESCRIPTION
## Summary
- fix CI to use gradle/gradle-build-action@v3
- add SQLite persistence layer and PBKDF2 password hashing
- implement AuthManager and /heneria register|login|logout commands
- bump version to 0.0.2

## Testing
- `gradle clean build --no-daemon -Dorg.gradle.jvmargs="-Xmx2g"`


------
https://chatgpt.com/codex/tasks/task_e_689e15c4b91c83249b5a0e7a1162be90