### PR TITLE
HC-05: add network wrapper with rate limiting, backoff and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
 ## 0.0.4
 - Add SkinService with ProtocolLib and Paper reflection fallback.
 - Cache signed textures and apply them on AuthPostLoginEvent.
+
+## 0.0.5
+- Add HttpClientWrapper with rate limiter, backoff strategy, circuit breaker and metrics.
+- Expose metrics through DebugInfoProvider and extend configuration.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HeneriaCore
 
-Initial skeleton for HeneriaCore plugin (Spigot/Paper 1.21). Version 0.0.4.
+Initial skeleton for HeneriaCore plugin (Spigot/Paper 1.21). Version 0.0.5.
 
 Important:
 - Do NOT commit gradle-wrapper.jar (gradle/wrapper/gradle-wrapper.jar).
@@ -20,3 +20,7 @@ Serve JSON responses matching the Mojang API formats for `/users/profiles/minecr
 ### Skins
 
 HC-04 introduces a basic `SkinService` able to apply signed textures either via ProtocolLib or Paper reflection as a fallback.
+
+### HC-05 network layer
+
+Adds an asynchronous `HttpClientWrapper` with token bucket rate limiting, exponential backoff, circuit breaker and metrics collection. Configuration lives under `mojang` in `config.yml`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.4
+version=0.0.5

--- a/src/main/java/fr/heneriacore/debug/DebugInfoProvider.java
+++ b/src/main/java/fr/heneriacore/debug/DebugInfoProvider.java
@@ -1,0 +1,20 @@
+package fr.heneriacore.debug;
+
+import fr.heneriacore.metrics.MetricsCollector;
+
+import java.util.Map;
+
+/**
+ * Provides debug information about network metrics.
+ */
+public class DebugInfoProvider {
+    private final MetricsCollector metrics;
+
+    public DebugInfoProvider(MetricsCollector metrics) {
+        this.metrics = metrics;
+    }
+
+    public Map<String, Object> getDebugInfo() {
+        return metrics.snapshot();
+    }
+}

--- a/src/main/java/fr/heneriacore/metrics/MetricsCollector.java
+++ b/src/main/java/fr/heneriacore/metrics/MetricsCollector.java
@@ -1,0 +1,51 @@
+package fr.heneriacore.metrics;
+
+import java.time.Clock;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Simple metrics collector for Mojang API calls.
+ */
+public class MetricsCollector {
+    private final LongAdder hits = new LongAdder();
+    private final LongAdder successes = new LongAdder();
+    private final LongAdder failures = new LongAdder();
+    private final LongAdder retries = new LongAdder();
+    private final LongAdder throttled = new LongAdder();
+    private final AtomicReference<String> circuitState = new AtomicReference<>("CLOSED");
+    private final AtomicLong lastFailureTs = new AtomicLong(0);
+    private final Clock clock;
+
+    public MetricsCollector(Clock clock) {
+        this.clock = clock;
+    }
+
+    public MetricsCollector() { this(Clock.systemUTC()); }
+
+    public void incHits() { hits.increment(); }
+    public void incSuccess() { successes.increment(); }
+    public void incFailure() {
+        failures.increment();
+        lastFailureTs.set(clock.millis());
+    }
+    public void incRetry() { retries.increment(); }
+    public void incThrottled() { throttled.increment(); }
+
+    public void setCircuitState(String state) { circuitState.set(state); }
+
+    public Map<String, Object> snapshot() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("mojang.hits", hits.sum());
+        map.put("mojang.successes", successes.sum());
+        map.put("mojang.failures", failures.sum());
+        map.put("mojang.retries", retries.sum());
+        map.put("mojang.throttled", throttled.sum());
+        map.put("mojang.circuit_state", circuitState.get());
+        map.put("mojang.last_failure_ts", lastFailureTs.get());
+        return map;
+    }
+}

--- a/src/main/java/fr/heneriacore/net/BackoffStrategy.java
+++ b/src/main/java/fr/heneriacore/net/BackoffStrategy.java
@@ -1,0 +1,31 @@
+package fr.heneriacore.net;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Exponential backoff with optional jitter.
+ */
+public class BackoffStrategy {
+    private final long baseDelayMs;
+    private final long maxDelayMs;
+    private final double jitter;
+
+    public BackoffStrategy(long baseDelayMs, long maxDelayMs, double jitter) {
+        this.baseDelayMs = baseDelayMs;
+        this.maxDelayMs = maxDelayMs;
+        this.jitter = jitter;
+    }
+
+    public long nextDelayMs(int retryCount) {
+        long delay = baseDelayMs * (1L << retryCount);
+        if (delay < 0) delay = Long.MAX_VALUE;
+        if (jitter > 0d) {
+            long delta = (long) (delay * jitter);
+            long min = Math.max(0L, delay - delta);
+            long max = delay + delta;
+            delay = ThreadLocalRandom.current().nextLong(min, max + 1);
+        }
+        if (delay > maxDelayMs) delay = maxDelayMs;
+        return delay;
+    }
+}

--- a/src/main/java/fr/heneriacore/net/CircuitBreaker.java
+++ b/src/main/java/fr/heneriacore/net/CircuitBreaker.java
@@ -1,0 +1,82 @@
+package fr.heneriacore.net;
+
+import java.time.Clock;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Simple circuit breaker with CLOSED, OPEN and HALF_OPEN states.
+ */
+public class CircuitBreaker {
+    public enum State { CLOSED, OPEN, HALF_OPEN }
+
+    private final int failureThreshold;
+    private final long openDurationMs;
+    private final int halfOpenProbeCount;
+    private final Clock clock;
+
+    private final AtomicReference<State> state = new AtomicReference<>(State.CLOSED);
+    private final AtomicInteger consecutiveFailures = new AtomicInteger();
+    private volatile long openTimestamp;
+    private volatile int halfOpenAttempts;
+
+    public CircuitBreaker(int failureThreshold, long openDurationMs, int halfOpenProbeCount, Clock clock) {
+        this.failureThreshold = failureThreshold;
+        this.openDurationMs = openDurationMs;
+        this.halfOpenProbeCount = halfOpenProbeCount;
+        this.clock = clock;
+    }
+
+    public CircuitBreaker(int failureThreshold, long openDurationMs, int halfOpenProbeCount) {
+        this(failureThreshold, openDurationMs, halfOpenProbeCount, Clock.systemUTC());
+    }
+
+    public boolean allowRequest() {
+        State s = state.get();
+        if (s == State.CLOSED) return true;
+        long now = clock.millis();
+        if (s == State.OPEN) {
+            if (now - openTimestamp >= openDurationMs) {
+                state.set(State.HALF_OPEN);
+                halfOpenAttempts = 0;
+                return true;
+            }
+            return false;
+        }
+        // HALF_OPEN
+        if (halfOpenAttempts < halfOpenProbeCount) {
+            halfOpenAttempts++;
+            return true;
+        }
+        return false;
+    }
+
+    public void onSuccess() {
+        if (state.get() != State.CLOSED) {
+            state.set(State.CLOSED);
+        }
+        consecutiveFailures.set(0);
+    }
+
+    public void onFailure() {
+        if (state.get() == State.CLOSED) {
+            int fail = consecutiveFailures.incrementAndGet();
+            if (fail >= failureThreshold) {
+                state.set(State.OPEN);
+                openTimestamp = clock.millis();
+            }
+        } else if (state.get() == State.HALF_OPEN) {
+            state.set(State.OPEN);
+            openTimestamp = clock.millis();
+        }
+    }
+
+    public State getState() {
+        State s = state.get();
+        if (s == State.OPEN && clock.millis() - openTimestamp >= openDurationMs) {
+            state.compareAndSet(State.OPEN, State.HALF_OPEN);
+            s = state.get();
+        }
+        return s;
+    }
+}

--- a/src/main/java/fr/heneriacore/net/HttpClientWrapper.java
+++ b/src/main/java/fr/heneriacore/net/HttpClientWrapper.java
@@ -1,0 +1,99 @@
+package fr.heneriacore.net;
+
+import fr.heneriacore.metrics.MetricsCollector;
+import fr.heneriacore.net.exceptions.CircuitOpenException;
+import fr.heneriacore.net.exceptions.RateLimitException;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wrapper around HttpClient providing rate limiting, retries and circuit breaker.
+ */
+public class HttpClientWrapper {
+    private final HttpClient client;
+    private final RateLimiter rateLimiter;
+    private final BackoffStrategy backoff;
+    private final CircuitBreaker circuitBreaker;
+    private final MetricsCollector metrics;
+    private final ScheduledExecutorService scheduler;
+    private final int maxRetries;
+
+    public HttpClientWrapper(HttpClient client,
+                             RateLimiter rateLimiter,
+                             BackoffStrategy backoff,
+                             CircuitBreaker circuitBreaker,
+                             MetricsCollector metrics,
+                             RetryPolicy policy,
+                             ScheduledExecutorService scheduler) {
+        this.client = client;
+        this.rateLimiter = rateLimiter;
+        this.backoff = backoff;
+        this.circuitBreaker = circuitBreaker;
+        this.metrics = metrics;
+        this.scheduler = scheduler;
+        this.maxRetries = policy.getMaxRetries();
+    }
+
+    public CompletableFuture<HttpResponse<String>> getAsync(URI uri, Map<String, String> headers) {
+        metrics.incHits();
+        metrics.setCircuitState(circuitBreaker.getState().name());
+        if (!circuitBreaker.allowRequest()) {
+            metrics.setCircuitState(circuitBreaker.getState().name());
+            return CompletableFuture.failedFuture(new CircuitOpenException("circuit open"));
+        }
+        if (!rateLimiter.tryConsume()) {
+            metrics.incThrottled();
+            return CompletableFuture.failedFuture(new RateLimitException("rate limit exceeded"));
+        }
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri).GET();
+        if (headers != null) headers.forEach(builder::header);
+        HttpRequest request = builder.build();
+        CompletableFuture<HttpResponse<String>> result = new CompletableFuture<>();
+        send(request, 0, result);
+        return result;
+    }
+
+    private void send(HttpRequest request, int attempt, CompletableFuture<HttpResponse<String>> result) {
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .whenComplete((resp, ex) -> {
+                    if (ex == null && resp.statusCode() >= 200 && resp.statusCode() < 300) {
+                        metrics.incSuccess();
+                        circuitBreaker.onSuccess();
+                        metrics.setCircuitState(circuitBreaker.getState().name());
+                        result.complete(resp);
+                    } else if (ex == null && resp.statusCode() >= 400 && resp.statusCode() < 500) {
+                        metrics.incSuccess();
+                        circuitBreaker.onSuccess();
+                        metrics.setCircuitState(circuitBreaker.getState().name());
+                        result.complete(resp);
+                    } else {
+                        if (attempt < maxRetries) {
+                            metrics.incRetry();
+                            long delay = backoff.nextDelayMs(attempt);
+                            scheduler.schedule(() -> send(request, attempt + 1, result), delay, TimeUnit.MILLISECONDS);
+                        } else {
+                            metrics.incFailure();
+                            circuitBreaker.onFailure();
+                            metrics.setCircuitState(circuitBreaker.getState().name());
+                            Throwable cause = ex != null ? ex : new RuntimeException("HTTP " + (resp != null ? resp.statusCode() : "error"));
+                            result.completeExceptionally(cause);
+                        }
+                    }
+                });
+    }
+
+    public CompletableFuture<String> getJsonAsync(URI uri, Map<String, String> headers) {
+        return getAsync(uri, headers).thenApply(HttpResponse::body);
+    }
+
+    public void shutdown() {
+        scheduler.shutdownNow();
+    }
+}

--- a/src/main/java/fr/heneriacore/net/RateLimiter.java
+++ b/src/main/java/fr/heneriacore/net/RateLimiter.java
@@ -1,0 +1,70 @@
+package fr.heneriacore.net;
+
+import java.time.Clock;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Simple token bucket rate limiter.
+ */
+public class RateLimiter {
+    private final int capacity;
+    private final long refillTokensPerMs;
+    private final Clock clock;
+    private final AtomicLong availableTokens;
+    private final AtomicLong lastRefillMs;
+
+    public RateLimiter(int requestsPerMinute, int burst, Clock clock) {
+        if (requestsPerMinute <= 0 || burst <= 0) {
+            throw new IllegalArgumentException("rpm and burst must be > 0");
+        }
+        this.capacity = burst;
+        this.refillTokensPerMs = requestsPerMinute * 1000L / 60000L; // tokens per ms scaled by 1000
+        this.clock = clock;
+        this.availableTokens = new AtomicLong(burst);
+        this.lastRefillMs = new AtomicLong(clock.millis());
+    }
+
+    public RateLimiter(int requestsPerMinute, int burst) {
+        this(requestsPerMinute, burst, Clock.systemUTC());
+    }
+
+    /**
+     * Try to consume tokens from the bucket.
+     *
+     * @return true if enough tokens were available
+     */
+    public boolean tryConsume(int tokens) {
+        refill();
+        while (true) {
+            long cur = availableTokens.get();
+            if (cur < tokens) return false;
+            if (availableTokens.compareAndSet(cur, cur - tokens)) return true;
+        }
+    }
+
+    public boolean tryConsume() {
+        return tryConsume(1);
+    }
+
+    /**
+     * @return current available tokens
+     */
+    public int getAvailableTokens() {
+        refill();
+        return (int) Math.min(Integer.MAX_VALUE, availableTokens.get());
+    }
+
+    private void refill() {
+        long now = clock.millis();
+        long last = lastRefillMs.get();
+        long elapsed = now - last;
+        if (elapsed <= 0) return;
+        long tokensToAdd = elapsed * refillTokensPerMs / 1000L;
+        if (tokensToAdd <= 0) return;
+        long newTimestamp = last + elapsed;
+        if (lastRefillMs.compareAndSet(last, newTimestamp)) {
+            availableTokens.updateAndGet(cur -> Math.min(capacity, cur + tokensToAdd));
+        }
+    }
+}
+

--- a/src/main/java/fr/heneriacore/net/RetryPolicy.java
+++ b/src/main/java/fr/heneriacore/net/RetryPolicy.java
@@ -1,0 +1,23 @@
+package fr.heneriacore.net;
+
+/**
+ * Immutable configuration for retry behavior.
+ */
+public class RetryPolicy {
+    private final int maxRetries;
+    private final long baseDelayMs;
+    private final long maxDelayMs;
+    private final double jitter;
+
+    public RetryPolicy(int maxRetries, long baseDelayMs, long maxDelayMs, double jitter) {
+        this.maxRetries = maxRetries;
+        this.baseDelayMs = baseDelayMs;
+        this.maxDelayMs = maxDelayMs;
+        this.jitter = jitter;
+    }
+
+    public int getMaxRetries() { return maxRetries; }
+    public long getBaseDelayMs() { return baseDelayMs; }
+    public long getMaxDelayMs() { return maxDelayMs; }
+    public double getJitter() { return jitter; }
+}

--- a/src/main/java/fr/heneriacore/net/exceptions/CircuitOpenException.java
+++ b/src/main/java/fr/heneriacore/net/exceptions/CircuitOpenException.java
@@ -1,0 +1,10 @@
+package fr.heneriacore.net.exceptions;
+
+/**
+ * Thrown when circuit breaker is open and request is rejected.
+ */
+public class CircuitOpenException extends RuntimeException {
+    public CircuitOpenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/heneriacore/net/exceptions/RateLimitException.java
+++ b/src/main/java/fr/heneriacore/net/exceptions/RateLimitException.java
@@ -1,0 +1,10 @@
+package fr.heneriacore.net.exceptions;
+
+/**
+ * Thrown when the rate limiter rejects a request.
+ */
+public class RateLimitException extends RuntimeException {
+    public RateLimitException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,3 +28,16 @@ auth:
     storage:
       type: sqlite # or yaml
       file: data/heneria_skins.db
+mojang:
+  rate:
+    requests_per_minute: 120
+    burst: 20
+  retries:
+    max_retries: 5
+    base_delay_ms: 500
+    max_delay_ms: 30000
+    jitter: 0.2
+  circuit:
+    failure_threshold: 5
+    open_duration_ms: 60000
+    half_open_probe_count: 2

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HeneriaCore
 main: fr.heneriacore.HeneriaCore
- version: "0.0.4"
+ version: "0.0.5"
 api-version: "1.21"
 description: "HeneriaCore - monolithic plugin (premium auth + auth-local + skins). Skeleton init."
 authors: ["OpenAI"]

--- a/src/test/java/fr/heneriacore/net/BackoffStrategyTest.java
+++ b/src/test/java/fr/heneriacore/net/BackoffStrategyTest.java
@@ -1,0 +1,23 @@
+package fr.heneriacore.net;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BackoffStrategyTest {
+    @Test
+    void testDelays() {
+        BackoffStrategy b = new BackoffStrategy(100, 1000, 0.0);
+        assertEquals(100, b.nextDelayMs(0));
+        assertEquals(200, b.nextDelayMs(1));
+        assertEquals(800, b.nextDelayMs(3));
+        assertEquals(1000, b.nextDelayMs(10)); // clamped
+    }
+
+    @Test
+    void testJitterRange() {
+        BackoffStrategy b = new BackoffStrategy(100, 1000, 0.2); // 20% jitter
+        long delay = b.nextDelayMs(2); // base 400
+        assertTrue(delay >= 320 && delay <= 480);
+    }
+}

--- a/src/test/java/fr/heneriacore/net/CircuitBreakerTest.java
+++ b/src/test/java/fr/heneriacore/net/CircuitBreakerTest.java
@@ -1,0 +1,37 @@
+package fr.heneriacore.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CircuitBreakerTest {
+    static class MutableClock extends Clock {
+        private long ms;
+        MutableClock(long start) { this.ms = start; }
+        void add(long delta) { ms += delta; }
+        @Override public ZoneId getZone() { return ZoneId.of("UTC"); }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public long millis() { return ms; }
+        @Override public Instant instant() { return Instant.ofEpochMilli(ms); }
+    }
+
+    @Test
+    void testTransitions() {
+        MutableClock clock = new MutableClock(0);
+        CircuitBreaker cb = new CircuitBreaker(2, 1000, 1, clock);
+        assertTrue(cb.allowRequest());
+        cb.onFailure();
+        assertEquals(CircuitBreaker.State.CLOSED, cb.getState());
+        cb.onFailure();
+        assertEquals(CircuitBreaker.State.OPEN, cb.getState());
+        assertFalse(cb.allowRequest());
+        clock.add(1000);
+        assertTrue(cb.allowRequest()); // HALF_OPEN probe
+        cb.onSuccess();
+        assertEquals(CircuitBreaker.State.CLOSED, cb.getState());
+    }
+}

--- a/src/test/java/fr/heneriacore/net/RateLimiterTest.java
+++ b/src/test/java/fr/heneriacore/net/RateLimiterTest.java
@@ -1,0 +1,33 @@
+package fr.heneriacore.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimiterTest {
+    static class MutableClock extends Clock {
+        private long millis;
+        MutableClock(long start) { this.millis = start; }
+        void addMillis(long ms) { this.millis += ms; }
+        @Override public ZoneId getZone() { return ZoneId.of("UTC"); }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public long millis() { return millis; }
+        @Override public Instant instant() { return Instant.ofEpochMilli(millis); }
+    }
+
+    @Test
+    void testConsumeAndRefill() {
+        MutableClock clock = new MutableClock(0);
+        RateLimiter rl = new RateLimiter(60, 10, clock); // 1 token/sec
+        assertTrue(rl.tryConsume(5));
+        assertEquals(5, rl.getAvailableTokens());
+        assertTrue(rl.tryConsume(5));
+        assertFalse(rl.tryConsume());
+        clock.addMillis(1000); // +1 token
+        assertTrue(rl.tryConsume());
+    }
+}


### PR DESCRIPTION
## Summary
- implement token-bucket `RateLimiter` and `BackoffStrategy`
- add `CircuitBreaker` and metrics collector with debug provider
- create `HttpClientWrapper` with retries, rate limiting and circuit breaking
- expand config and bump version to 0.0.5
- document new network layer

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689e448a73048324b5e37ef787460d43