### PR TITLE
HC-08: release docs and withPlib workflow

### DIFF
--- a/.github/workflows/release-with-plib.yml
+++ b/.github/workflows/release-with-plib.yml
@@ -1,0 +1,110 @@
+name: release-with-plib
+
+on:
+  workflow_dispatch:
+    inputs:
+      protocollib_source:
+        description: 'github-packages | s3 | manual-upload'
+        required: true
+        type: choice
+        options:
+          - github-packages
+          - s3
+          - manual-upload
+      protocollib_ref:
+        description: 'tag, S3 key or URL'
+        required: false
+      version:
+        description: 'override version'
+        required: false
+      release_notes:
+        description: 'additional release notes'
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: '8.14.3'
+      - name: Determine version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_VERSION=$(grep '^version=' gradle.properties | cut -d= -f2)" >> $GITHUB_ENV
+          fi
+      - name: Download ProtocolLib (GitHub Packages)
+        if: ${{ github.event.inputs.protocollib_source == 'github-packages' }}
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          test -n "$GH_PACKAGES_TOKEN" || { echo 'GH_PACKAGES_TOKEN missing'; exit 1; }
+          mkdir -p libs
+          curl -L -H "Authorization: token $GH_PACKAGES_TOKEN" "${{ github.event.inputs.protocollib_ref }}" -o libs/ProtocolLib.jar
+      - name: Download ProtocolLib (S3)
+        if: ${{ github.event.inputs.protocollib_source == 's3' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          test -n "$S3_BUCKET" || { echo 'S3_BUCKET missing'; exit 1; }
+          mkdir -p libs
+          aws s3 cp "s3://$S3_BUCKET/${{ github.event.inputs.protocollib_ref }}" libs/ProtocolLib.jar
+      - name: Download ProtocolLib (manual upload)
+        if: ${{ github.event.inputs.protocollib_source == 'manual-upload' }}
+        env:
+          PROTOCOLLIB_UPLOAD_URL: ${{ secrets.PROTOCOLLIB_UPLOAD_URL }}
+        run: |
+          URL="${{ github.event.inputs.protocollib_ref }}"
+          if [ -z "$URL" ]; then
+            URL="$PROTOCOLLIB_UPLOAD_URL"
+          fi
+          test -n "$URL" || { echo 'No ProtocolLib URL provided'; exit 1; }
+          mkdir -p libs
+          curl -L "$URL" -o libs/ProtocolLib.jar
+      - name: Verify ProtocolLib jar
+        run: |
+          test -f libs/ProtocolLib.jar || { echo 'ProtocolLib jar missing'; exit 1; }
+      - name: Build with ProtocolLib
+        run: ./gradlew -PwithPlib=true -PwithPlibLocal=./libs/ProtocolLib.jar clean shadowJar test
+      - name: Package checksum
+        run: sha256sum build/libs/HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar > build/libs/HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar.sha256
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.RELEASE_VERSION }}
+          release_name: v${{ env.RELEASE_VERSION }}
+          draft: true
+          body: ${{ github.event.inputs.release_notes }}
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/libs/HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar
+          asset_name: HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar
+          asset_content_type: application/java-archive
+      - name: Upload checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/libs/HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar.sha256
+          asset_name: HeneriaCore-withPlib-${{ env.RELEASE_VERSION }}.jar.sha256
+          asset_content_type: text/plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,8 @@
 - Add per-player opt-in/out preferences stored in SQLite.
 - Implement `/heneria optin`, `/heneria optout`, `/heneria prefs` and admin `/heneria debug`.
 - Skip auto skin apply, auto-login and claim flows when players opt out.
+
+## 0.0.8
+- Add production and release documentation.
+- Introduce release-with-plib workflow to bundle ProtocolLib.
+- Update version to 0.0.8 and provide release checklist.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # HeneriaCore
 
-Initial skeleton for HeneriaCore plugin (Spigot/Paper 1.21). Version 0.0.7.
+Initial skeleton for HeneriaCore plugin (Spigot/Paper 1.21). Version 0.0.8.
 
 Important:
 - Do NOT commit gradle-wrapper.jar (gradle/wrapper/gradle-wrapper.jar).
 - CI installs Gradle using gradle/setup-gradle.
 - Development: install Gradle 8.x locally or run `gradle wrapper` locally (do NOT commit generated jar).
+
+### Production
+
+See [docs/PRODUCTION.md](docs/PRODUCTION.md) for deploying on Spigot or Paper and FAQs on spoofing, opt-in and claim.
+
 
 ### Testing Mojang API locally
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,16 @@
+# Release Checklist
+
+Before publishing a release ensure the following:
+
+- [ ] CI is green on `main` or `develop`.
+- [ ] `./gradlew test` passes locally.
+- [ ] Manual smoke test on:
+  - [ ] Spigot with ProtocolLib installed.
+  - [ ] Paper without ProtocolLib (reflection fallback).
+- [ ] Migration scripts and database schema version verified.
+- [ ] Example `config.production.yml` reviewed and updated.
+- [ ] `CHANGELOG.md` updated for the target version.
+- [ ] `release-with-plib` workflow ran and produced `HeneriaCore-withPlib-<version>.jar` and checksum.
+- [ ] Tag `v<version>` created and GitHub release drafted with artifact and SHA256.
+- [ ] Announced to server admins and internal registries updated.
+- [ ] Previous release artifact stored for rollback and any tokens/URLs used for ProtocolLib are rotated.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,47 @@
+# Production Guide
+
+## Server Selection
+
+HeneriaCore supports Spigot and Paper for Minecraft 1.21. Paper is recommended for performance and for the reflection fallback when ProtocolLib is missing. Spigot works but may require ProtocolLib for advanced features.
+
+1. Download either [Spigot](https://www.spigotmc.org/) or [Paper](https://papermc.io/).
+2. Place `HeneriaCore.jar` in the server `plugins/` directory.
+3. Provide ProtocolLib:
+   - Use the regular artifact and install the ProtocolLib plugin manually.
+   - Or use the `withPlib` build produced by the release workflow which bundles ProtocolLib and avoids the extra dependency.
+
+## Prerequisites
+
+- Java 21 runtime.
+- Network access to Mojang APIs.
+- Optional SQLite database backup strategy.
+
+## Recommended Configuration
+
+Copy the default `config.yml` and adjust for production:
+
+- Tune `mojang.rateLimit` to stay under Mojang limits.
+- Enable database backups and logging according to your policy.
+- Review `preferences` defaults for opt‑in behaviour.
+
+## Admin Commands
+
+- `/heneria claim start <name>` – begin a claim flow.
+- `/heneria claim check <id>` – verify claim.
+- `/heneria optin` / `/heneria optout` – player preferences.
+- `/heneria prefs` – show current preferences.
+- `/heneria debug` – inspect internal state.
+
+## FAQ
+
+**Spoofing / premium detection**
+: The plugin queries Mojang's session servers. Spoofed names are rejected before login completes.
+
+**Opt‑in / opt‑out**
+: Players control automatic skin and claim features with `/heneria optin` and `/heneria optout`. Admins can override via permissions.
+
+**Claim flow**
+: Claims prove account ownership. Start with `/heneria claim start <name>` which generates a tokenised skin. The player applies it and you verify with `/heneria claim check <id>`.
+
+**Spigot vs Paper**
+: Paper includes extra API and async improvements. When ProtocolLib is absent Paper uses a reflection fallback for skin changes. On Spigot you must provide ProtocolLib unless using the `withPlib` release.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,55 @@
+# Release Process
+
+This guide is for maintainers creating a production release of HeneriaCore.
+
+## Preparation
+
+1. Ensure `CHANGELOG.md` and version numbers are updated.
+2. Commit and push all changes to `main` or `develop`.
+3. Verify CI is green and run the manual tests in `RELEASE_CHECKLIST.md`.
+
+## Trigger the `release-with-plib` Workflow
+
+The workflow bundles ProtocolLib into the plugin and creates a GitHub release. It is triggered manually using **workflow_dispatch**.
+
+Inputs:
+- `protocollib_source` – one of `github-packages`, `s3`, or `manual-upload`.
+- `protocollib_ref` – tag, S3 key or URL depending on the source.
+- `version` – optional override; defaults to `gradle.properties` value.
+- `release_notes` – optional text appended to the GitHub release.
+
+## Providing ProtocolLib
+
+### GitHub Packages (recommended)
+1. Upload `ProtocolLib.jar` to a private repository release or package.
+2. Store a token with `read:packages` permission in `GH_PACKAGES_TOKEN`.
+3. Dispatch the workflow with `protocollib_source=github-packages` and set `protocollib_ref` to the asset tag or ID.
+4. The job downloads the jar using `curl -H "Authorization: token $GH_PACKAGES_TOKEN"`.
+
+### S3
+1. Upload the jar to a private S3 bucket.
+2. Store `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `S3_BUCKET` secrets.
+3. Dispatch with `protocollib_source=s3` and `protocollib_ref` set to the object key.
+4. The job runs `aws s3 cp s3://$S3_BUCKET/$protocollib_ref ./libs/ProtocolLib.jar`.
+
+### Manual Upload
+1. Generate a short‑lived, pre‑signed URL to the jar.
+2. Store it as the secret `PROTOCOLLIB_UPLOAD_URL` or pass via `protocollib_ref`.
+3. Dispatch with `protocollib_source=manual-upload`.
+4. The job downloads with `curl -L "$PROTOCOLLIB_UPLOAD_URL" -o ./libs/ProtocolLib.jar`.
+
+## Build and Release
+
+1. The workflow validates the jar, then runs:
+   ```bash
+   ./gradlew -PwithPlib=true -PwithPlibLocal=./libs/ProtocolLib.jar clean shadowJar test
+   ```
+2. The artifact `HeneriaCore-withPlib-<version>.jar` and its SHA256 checksum are produced in `build/libs/`.
+3. A draft GitHub release `v<version>` is created and both files are uploaded.
+4. Review the release, add final notes, and publish.
+
+## Post Release
+
+- Announce in the server admin channel.
+- Upload the artifact to internal mirrors if required.
+- Plan rollback: keep previous release jar handy in case of issues.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,15 @@
+# Troubleshooting
+
+Common issues and their fixes.
+
+## ProtocolLib mismatch
+If login packets fail or skins do not apply, ensure the ProtocolLib version matches the server. Use the `withPlib` build or install a compatible ProtocolLib release.
+
+## Packet flicker
+Rapid skin changes may cause packet flicker. Update ProtocolLib and avoid other plugins modifying the same packets.
+
+## Tablist issues
+Incorrect tablist names or skins usually stem from outdated client information. Clear tablist caches or restart the server.
+
+## Mojang rate limits
+When the Mojang API returns rate limit errors, increase `mojang.rateLimit` delay or provide a cache. The plugin will back off automatically but repeated failures may block authentication.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.7
+version=0.0.8

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HeneriaCore
 main: fr.heneriacore.HeneriaCore
- version: "0.0.7"
+ version: "0.0.8"
 api-version: "1.21"
 description: "HeneriaCore - monolithic plugin (premium auth + auth-local + skins). Skeleton init."
 authors: ["OpenAI"]


### PR DESCRIPTION
## Summary
- add production, release and troubleshooting docs
- add release-with-plib workflow for bundling ProtocolLib
- bump version to 0.0.8 and add release checklist and changelog entry

## Testing
- `gradle test`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_689e54557e808324819d6fb52a2f6a65