### PR TITLE
[HC-08.2-BUGFIX] NPE au boot (getCommand(...) == null) — aligner plugin.yml + bind sûr des commandes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,18 @@ with open('src/main/resources/plugin.yml', 'rb') as f:
 print('YAML OK')
 PY
 
+      - name: Validate commands presence
+        run: |
+          set -e
+          CMDS=$( { grep -R --line-number 'getCommand("' src/main/java || true; grep -R --line-number 'bind("' src/main/java || true; } | sed -E 's/.*(getCommand|bind)\("([^"]+)".*/\2/' | sort -u )
+          echo "Code expects commands: $CMDS"
+          for c in $CMDS; do
+            if ! awk '/^commands:/{f=1;next} f&&/^[^[:space:]]/{f=0} f{print}' src/main/resources/plugin.yml | grep -qE "^[[:space:]]+$c:" ; then
+              echo "::error::Command '$c' not declared under 'commands:' in plugin.yml"
+              exit 1
+            fi
+          done
+          echo "Commands validation OK"
+
       - name: Build
         run: gradle clean build --no-daemon -Dorg.gradle.jvmargs="-Xmx2g"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,7 @@
 
 ## 0.0.8.1 (Hotfix)
 - Fix: Invalid plugin.yml (tabs/BOM/CRLF/indent) causing InvalidDescriptionException on load.
+
+## 0.0.8.2 (Hotfix)
+- Fix NPE on enable caused by missing command declaration in plugin.yml.
+- Add null-safe command binding and CI guard for command declarations.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.8.1
+version=0.0.8.2

--- a/src/main/java/fr/heneriacore/HeneriaCore.java
+++ b/src/main/java/fr/heneriacore/HeneriaCore.java
@@ -14,6 +14,10 @@ import fr.heneriacore.premium.PremiumDetector;
 import fr.heneriacore.premium.SessionProfileResolver;
 import fr.heneriacore.skin.*;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.logging.Level;
@@ -71,8 +75,7 @@ public final class HeneriaCore extends JavaPlugin {
         PreferencesCommand prefsCmd = new PreferencesCommand(this, preferencesManager);
         DebugCommand debugCmd = new DebugCommand(this, sqliteManager, preferencesManager, skinService, textureCache);
         AuthCommand authCmd = new AuthCommand(this, claimCmd, prefsCmd, debugCmd);
-        getCommand("heneria").setExecutor(authCmd);
-        getCommand("heneria").setTabCompleter(authCmd);
+        bind("heneria", authCmd, authCmd);
         getServer().getScheduler().runTaskTimerAsynchronously(this, claimManager::cleanupExpired, 20L, 20L * 60);
     }
 
@@ -92,4 +95,16 @@ public final class HeneriaCore extends JavaPlugin {
     public ClaimManager getClaimManager() { return claimManager; }
 
     public PreferencesManager getPreferencesManager() { return preferencesManager; }
+
+    private void bind(String cmd, CommandExecutor exec, @Nullable TabCompleter tab) {
+        PluginCommand c = getCommand(cmd);
+        if (c == null) {
+            getLogger().severe("Missing command in plugin.yml: " + cmd);
+            return;
+        }
+        c.setExecutor(exec);
+        if (tab != null) {
+            c.setTabCompleter(tab);
+        }
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,10 +1,28 @@
 name: HeneriaCore
 main: fr.heneriacore.HeneriaCore
-version: "0.0.8.1"
+version: "0.0.8.2"
 api-version: "1.21"
-description: "HeneriaCore - core auth/premium/skins"
-authors:
-  - "Heneria"
+description: "HeneriaCore - auth/premium/skins"
+authors: ["Heneria"]
 softdepend: [ProtocolLib]
-commands: {}
-permissions: {}
+
+commands:
+  heneria:
+    description: "HeneriaCore root command"
+    usage: "/heneria help"
+    aliases: [hc]
+    permission: "heneria.use"
+
+permissions:
+  heneria.use:
+    default: true
+  heneria.auth:
+    default: true
+  heneria.auth.admin:
+    default: op
+  heneria.claim:
+    default: true
+  heneria.claim.admin:
+    default: op
+  heneria.debug:
+    default: op


### PR DESCRIPTION
## Summary
- declare root `heneria` command and permissions in plugin.yml
- add null-safe `bind` helper for command registration
- guard CI against missing command entries
- bump version to 0.0.8.2 and document hotfix

## Testing
- `bash /tmp/validate.sh`
- `gradle clean build --no-daemon -Dorg.gradle.jvmargs="-Xmx2g"`

------
https://chatgpt.com/codex/tasks/task_e_689f111184048324ae0e27ece8c4dcbc