### PR TITLE
feat: add premium forwarding detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: gradle build --no-daemon
 
       - name: Show version
-        run: echo "Building Faskin 0.1.0"
+        run: echo "Building Faskin 0.1.0-SNAPSHOT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Services squelettes (PremiumDetector, AuthBypassService) et listeners.
 - Config/messages: blocs `premium.*`.
 - CI: artefact `Faskin-0.1.0-SNAPSHOT.jar`.
+- Détection premium via forwarding (UUID + textures) — sans bypass.
 ### Changed
 - Bump version plugin à `0.1.0`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plugin unifié Spigot 1.21 / Java 21 :
 1) Auth offline (Étape 1), 2) Auto-login premium (Étape 2), 3) Skins premium en offline (Étape 3).
 
 ## Version
-`0.1.0` — Étape 2 amorcée : ossature auto-login premium.
+`0.1.0-SNAPSHOT` — Étape 2 amorcée : ossature auto-login premium.
 
 ## Admin
 - `/faskin status [player]` : état runtime + méta compte (IP, lastLogin, compteur d’échecs, lock).
@@ -34,6 +34,19 @@ Plugin unifié Spigot 1.21 / Java 21 :
 
 ## Mode PROXY_SAFE recommandé
 Faskin privilégie un proxy en **online-mode** avec [player information forwarding](https://docs.papermc.io/velocity/player-information-forwarding/) activé. Cela permet de transmettre UUID, IP et propriétés signées pour un auto-login premium sécurisé. Sans forwarding, aucun bypass n'est effectué. Réfs : [FastLogin](https://www.spigotmc.org/resources/fastlogin.14153/), [Velocity](https://docs.papermc.io/velocity/player-information-forwarding/).
+
+## Pré-requis Étape 2 (PROXY_SAFE)
+Pour prouver qu'un joueur est premium, le proxy doit transférer son identité complète au backend.
+
+```toml
+# velocity.toml
+player-info-forwarding-mode = "modern"
+forwarding-secret = "<secret>"
+```
+
+Le même secret doit être défini côté backend (`velocity.toml` de Paper/Waterfall). Sans forwarding **IP/UUID/properties**, Faskin ne réalise aucune détection premium.
+
+L'API Paper 1.21 expose `Player#getPlayerProfile()` et `PlayerProfile#getTextures()` afin de récupérer les textures signées (skin). Toute modification manuelle invalide ces attributs signés.
 
 ## Build local (sans wrapper)
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,8 @@ Permettre aux comptes **premium vérifiés** d’entrer **sans mot de passe**, t
 3) `AUTHENTICATED` (création/renouvellement session IP si activée)
 
 ### Détection premium (règles)
-- Source: données de forwarding du proxy (UUID online + properties).  
+- Source: données de forwarding du proxy (UUID online + properties).
+- Inspection de `PlayerProfile#getTextures()` au `PlayerJoinEvent` : absence de skin ou profil non signé ⇒ pas de preuve premium.
 - Échec bypass si:
   - pas d’IP-forwarding,
   - pas d’UUID online,
@@ -116,4 +117,6 @@ _Notes sources_ :
 ## Prochaines étapes
 - Créer **tickets d’implémentation Étape 2** (T2.1 → T2.6) alignés sur la checklist ci-dessus (sans toucher à l’Étape 1).
 - Mettre à jour `README.md` avec un encart **“Mode PROXY_SAFE recommandé”** + extrait de config Velocity (`player-info-forwarding`) pour éviter les faux positifs et sécuriser le bypass.
-- [ ] T2.1 — Base auto-login premium (En cours)
+- [x] T2.1 — Base auto-login premium
+- [x] T2.2 — Détection premium via forwarding (UUID + textures)
+- [ ] T2.3 — Intégration bypass `/login`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=net.hika
-version=0.1.0
+version=0.1.0-SNAPSHOT
 org.gradle.jvmargs=-Xmx1g -XX:+UseParallelGC

--- a/src/main/java/com/faskin/auth/FaskinPlugin.java
+++ b/src/main/java/com/faskin/auth/FaskinPlugin.java
@@ -20,9 +20,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.io.File;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class FaskinPlugin extends JavaPlugin {
 
@@ -31,7 +28,6 @@ public final class FaskinPlugin extends JavaPlugin {
     private AuthServiceRegistry services;
     private BukkitTask reminderTask;
     private LoginTimeoutManager timeouts;
-    private final Map<UUID, com.faskin.auth.premium.PremiumEvaluation> premiumEvaluations = new ConcurrentHashMap<>();
 
     @Override
     public void onEnable() {
@@ -113,5 +109,4 @@ public final class FaskinPlugin extends JavaPlugin {
     public Messages messages() { return messages; }
     public AuthServiceRegistry services() { return services; }
     public LoginTimeoutManager getTimeouts() { return timeouts; }
-    public Map<UUID, com.faskin.auth.premium.PremiumEvaluation> premiumCache() { return premiumEvaluations; }
 }

--- a/src/main/java/com/faskin/auth/listeners/PremiumAsyncPreLoginListener.java
+++ b/src/main/java/com/faskin/auth/listeners/PremiumAsyncPreLoginListener.java
@@ -1,12 +1,9 @@
 package com.faskin.auth.listeners;
 
 import com.faskin.auth.FaskinPlugin;
-import com.faskin.auth.premium.PremiumEvaluation;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
-
-import java.util.UUID;
 
 public final class PremiumAsyncPreLoginListener implements Listener {
     private final FaskinPlugin plugin;
@@ -17,8 +14,6 @@ public final class PremiumAsyncPreLoginListener implements Listener {
 
     @EventHandler
     public void onAsyncPreLogin(AsyncPlayerPreLoginEvent e) {
-        PremiumEvaluation eval = plugin.services().premiumDetector().evaluate(e);
-        UUID id = e.getUniqueId();
-        plugin.premiumCache().put(id, eval);
+        plugin.services().premiumDetector().evaluatePreLogin(e);
     }
 }

--- a/src/main/java/com/faskin/auth/listeners/PremiumLoginListener.java
+++ b/src/main/java/com/faskin/auth/listeners/PremiumLoginListener.java
@@ -2,6 +2,7 @@ package com.faskin.auth.listeners;
 
 import com.faskin.auth.FaskinPlugin;
 import com.faskin.auth.premium.PremiumEvaluation;
+import com.faskin.auth.premium.PremiumEvaluatedEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -19,10 +20,7 @@ public final class PremiumLoginListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
-        PremiumEvaluation eval = plugin.premiumCache().remove(e.getPlayer().getUniqueId());
-        if (eval == PremiumEvaluation.PREMIUM_SAFE && plugin.configs().premiumSkipPassword()) {
-            plugin.services().authBypass().markAuthenticated(e.getPlayer().getUniqueId(), e.getPlayer().getName(), null, plugin.configs().premiumMode());
-            e.getPlayer().sendMessage(plugin.messages().prefixed("premium.bypass-ok"));
-        }
+        PremiumEvaluation eval = plugin.services().premiumDetector().evaluateJoin(e.getPlayer());
+        plugin.getServer().getPluginManager().callEvent(new PremiumEvaluatedEvent(e.getPlayer(), eval));
     }
 }

--- a/src/main/java/com/faskin/auth/premium/PremiumDetector.java
+++ b/src/main/java/com/faskin/auth/premium/PremiumDetector.java
@@ -1,7 +1,9 @@
 package com.faskin.auth.premium;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 
 public interface PremiumDetector {
-    PremiumEvaluation evaluate(AsyncPlayerPreLoginEvent e);
+    PremiumEvaluation evaluatePreLogin(AsyncPlayerPreLoginEvent e);
+    PremiumEvaluation evaluateJoin(Player player);
 }

--- a/src/main/java/com/faskin/auth/premium/PremiumEvaluatedEvent.java
+++ b/src/main/java/com/faskin/auth/premium/PremiumEvaluatedEvent.java
@@ -1,0 +1,30 @@
+package com.faskin.auth.premium;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+
+public final class PremiumEvaluatedEvent extends PlayerEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final PremiumEvaluation evaluation;
+
+    public PremiumEvaluatedEvent(Player who, PremiumEvaluation evaluation) {
+        super(who);
+        this.evaluation = evaluation;
+    }
+
+    public PremiumEvaluation getEvaluation() {
+        return evaluation;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}
+

--- a/src/main/java/com/faskin/auth/premium/impl/ProxyForwardingPremiumDetector.java
+++ b/src/main/java/com/faskin/auth/premium/impl/ProxyForwardingPremiumDetector.java
@@ -4,21 +4,68 @@ import com.faskin.auth.FaskinPlugin;
 import com.faskin.auth.premium.PremiumDetector;
 import com.faskin.auth.premium.PremiumEvaluation;
 import com.faskin.auth.premium.PremiumMode;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class ProxyForwardingPremiumDetector implements PremiumDetector {
+    private static final long TTL_MILLIS = Duration.ofMinutes(5).toMillis();
+
     private final FaskinPlugin plugin;
+    private final Map<UUID, Entry> pending = new ConcurrentHashMap<>();
 
     public ProxyForwardingPremiumDetector(FaskinPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
-    public PremiumEvaluation evaluate(AsyncPlayerPreLoginEvent e) {
+    public PremiumEvaluation evaluatePreLogin(AsyncPlayerPreLoginEvent e) {
         if (!plugin.configs().premiumEnabled()) return PremiumEvaluation.NOT_PREMIUM;
-        PremiumMode mode = plugin.configs().premiumMode();
-        if (mode != PremiumMode.PROXY_SAFE) return PremiumEvaluation.NOT_PREMIUM;
-        // TODO T2.2: check forwarding UUID + signed textures from proxy
-        return PremiumEvaluation.NOT_PREMIUM;
+        if (plugin.configs().premiumMode() != PremiumMode.PROXY_SAFE) return PremiumEvaluation.NOT_PREMIUM;
+
+        long now = System.currentTimeMillis();
+        cleanup(now);
+        UUID id = e.getUniqueId();
+        String ip = e.getAddress() != null ? e.getAddress().getHostAddress() : null;
+        pending.put(id, new Entry(id, e.getName(), ip, now + TTL_MILLIS));
+        return PremiumEvaluation.UNKNOWN;
     }
+
+    @Override
+    public PremiumEvaluation evaluateJoin(Player player) {
+        if (!plugin.configs().premiumEnabled()) return PremiumEvaluation.NOT_PREMIUM;
+        if (plugin.configs().premiumMode() != PremiumMode.PROXY_SAFE) return PremiumEvaluation.NOT_PREMIUM;
+
+        long now = System.currentTimeMillis();
+        cleanup(now);
+        Entry data = pending.remove(player.getUniqueId());
+        if (data == null || data.expiresAt < now) {
+            return PremiumEvaluation.NOT_PREMIUM;
+        }
+
+        PlayerProfile profile = player.getPlayerProfile();
+        PlayerTextures textures = profile.getTextures();
+        if (textures == null || textures.getSkin() == null) {
+            return PremiumEvaluation.NOT_PREMIUM;
+        }
+        try {
+            if (!textures.isSigned()) return PremiumEvaluation.NOT_PREMIUM;
+        } catch (NoSuchMethodError ignored) {
+            // older API without isSigned: assume valid
+        }
+        return PremiumEvaluation.PREMIUM_SAFE;
+    }
+
+    private void cleanup(long now) {
+        pending.values().removeIf(e -> e.expiresAt < now);
+    }
+
+    private record Entry(UUID uuid, String name, String ip, long expiresAt) {}
 }
+

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -46,3 +46,5 @@ premium:
   bypass-ok: "&aConnexion premium vérifiée. Authentifié automatiquement."
   bypass-refused: "&cBypass premium refusé: {reason}."
   unlink-ok: "&eTon compte premium est dissocié. Mot de passe requis au prochain login."
+  forwarding-missing: "&cProxy mal configuré (player-info-forwarding). Bypass premium indisponible."
+  no-textures: "&eProfil premium non prouvé (textures absentes)."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Faskin
 main: com.faskin.auth.FaskinPlugin
-version: 0.1.0
+version: 0.1.0-SNAPSHOT
 api-version: '1.21'
 authors: [ 'GordoxGit' ]
 website: 'https://github.com/GordoxGit/Faskin'


### PR DESCRIPTION
## Summary
- detect premium accounts from Velocity/Waterfall player-info-forwarding
- fire `PremiumEvaluatedEvent` after join for later bypass integration
- document proxy requirements and premium detection rules

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68a06420958083249650043b41807c06