### PR TITLE
Implement configurable file management via ConfigManager

### DIFF
--- a/src/main/java/fr/projetserveur/faskin/FaskinPlugin.java
+++ b/src/main/java/fr/projetserveur/faskin/FaskinPlugin.java
@@ -2,15 +2,25 @@ package fr.projetserveur.faskin;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import fr.projetserveur.faskin.managers.ConfigManager;
+
 public class FaskinPlugin extends JavaPlugin {
+
+    private ConfigManager configManager;
 
     @Override
     public void onEnable() {
+        this.configManager = new ConfigManager(this);
+        this.configManager.loadConfigs();
         this.getLogger().info("Faskin plugin enabled");
     }
 
     @Override
     public void onDisable() {
         this.getLogger().info("Faskin plugin disabled");
+    }
+
+    public ConfigManager getConfigManager() {
+        return configManager;
     }
 }

--- a/src/main/java/fr/projetserveur/faskin/managers/ConfigManager.java
+++ b/src/main/java/fr/projetserveur/faskin/managers/ConfigManager.java
@@ -1,0 +1,68 @@
+package fr.projetserveur.faskin.managers;
+
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+
+/**
+ * Central configuration handler for Faskin.
+ */
+public class ConfigManager {
+
+    private final JavaPlugin plugin;
+    private FileConfiguration config;
+    private FileConfiguration messages;
+    private String prefix;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Loads the configuration and message files from disk,
+     * creating default copies from the JAR if they do not yet exist.
+     */
+    public void loadConfigs() {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+
+        this.config = load("config.yml");
+        this.messages = load("messages.yml");
+        this.prefix = ChatColor.translateAlternateColorCodes('&', messages.getString("prefix", ""));
+    }
+
+    private FileConfiguration load(String fileName) {
+        File file = new File(plugin.getDataFolder(), fileName);
+        if (!file.exists()) {
+            plugin.saveResource(fileName, false);
+        }
+        return YamlConfiguration.loadConfiguration(file);
+    }
+
+    /**
+     * Reloads the configuration and message files from disk.
+     */
+    public void reloadConfigs() {
+        loadConfigs();
+    }
+
+    public FileConfiguration getConfig() {
+        return config;
+    }
+
+    /**
+     * Retrieves a message from messages.yml with the prefix applied
+     * and color codes translated.
+     *
+     * @param key message path in messages.yml
+     * @return formatted message string
+     */
+    public String getMessage(String key) {
+        String message = messages.getString(key, "");
+        return ChatColor.translateAlternateColorCodes('&', prefix + message);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,25 @@
+# Configuration file for Faskin
+#
+# database: settings for database connection
+# session: session handling options
+# restrictions: options controlling usage limits
+
+# Database settings
+# These options will be used for future database integrations
+# such as storing player data.
+database:
+  host: localhost
+  port: 3306
+  name: faskin
+  username: root
+  password: ""
+
+# Session settings
+session:
+  timeout: 300
+
+# Restrictions settings
+# Future restriction options will be added here.
+restrictions:
+  # placeholder for future options
+  enabled: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,6 @@
+# Default messages for Faskin
+# Colour codes supported using '&'
+
+prefix: "&8[&6Faskin&8] &r"
+plugin-reloaded: "&aLa configuration de Faskin a été rechargée."
+no-permission: "&cVous n'avez pas la permission d'exécuter cette commande."


### PR DESCRIPTION
## Summary
- add `ConfigManager` to handle `config.yml` and `messages.yml`
- populate default configuration and message files
- initialize manager from `FaskinPlugin`

## Testing
- `mvn package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a322d787688324a062cfb91c2b455a