### PR TITLE
feat: document configuration system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+## [0.0.1] - En développement
+### Ajouté
+- Mise en place du système de gestion de la configuration (`config.yml`, `messages.yml`).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Faskin
+
+## Fonctionnalités
+- Système de configuration entièrement personnalisable via `config.yml` et `messages.yml`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,7 @@
+# Roadmap Faskin
+- [x] **Étape 1 : Fondations du Projet**
+- [ ] **Étape 2 : Cœur Applicatif (En cours)**
+- [ ] **Étape 3 : Le Triage (Logique de Connexion)**
+- [ ] **Étape 4 : Le Portail (Authentification Manuelle)**
+- [ ] **Étape 5 : Le Tapis Rouge (Gestion Premium)**
+- [ ] **Étape 6 : Le Panneau de Contrôle (Finalisation & Admin)**

--- a/src/main/java/fr/projetserveur/faskin/managers/ConfigManager.java
+++ b/src/main/java/fr/projetserveur/faskin/managers/ConfigManager.java
@@ -55,6 +55,24 @@ public class ConfigManager {
     }
 
     /**
+     * Provides direct access to the messages configuration.
+     *
+     * @return loaded messages.yml configuration
+     */
+    public FileConfiguration getMessages() {
+        return messages;
+    }
+
+    /**
+     * Retrieves the formatted prefix defined in messages.yml.
+     *
+     * @return colorised prefix string
+     */
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
      * Retrieves a message from messages.yml with the prefix applied
      * and color codes translated.
      *


### PR DESCRIPTION
## Summary
- expose messages and prefix accessors in ConfigManager
- add README, roadmap, and changelog

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a32595847083249dd84c9c6933f381