### PR TITLE
feat: add player persistence layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 ## [0.0.1] - En développement
 ### Ajouté
 - Mise en place du système de gestion de la configuration (`config.yml`, `messages.yml`).
+- Implémentation de la couche de persistance des données (SQLite, cache joueur).

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 ## Fonctionnalités
 - Système de configuration entièrement personnalisable via `config.yml` et `messages.yml`.
+- Stockage des données joueurs via une base de données SQLite.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Faskin
 - [x] **Étape 1 : Fondations du Projet**
-- [ ] **Étape 2 : Cœur Applicatif (En cours)**
+- [x] **Étape 2 : Cœur Applicatif**
 - [ ] **Étape 3 : Le Triage (Logique de Connexion)**
 - [ ] **Étape 4 : Le Portail (Authentification Manuelle)**
 - [ ] **Étape 5 : Le Tapis Rouge (Gestion Premium)**

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/fr/projetserveur/faskin/FaskinPlugin.java
+++ b/src/main/java/fr/projetserveur/faskin/FaskinPlugin.java
@@ -1,26 +1,59 @@
 package fr.projetserveur.faskin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.PluginManager;
 
 import fr.projetserveur.faskin.managers.ConfigManager;
+import fr.projetserveur.faskin.managers.DatabaseManager;
+import fr.projetserveur.faskin.cache.PlayerCache;
+import fr.projetserveur.faskin.listeners.PlayerListener;
 
 public class FaskinPlugin extends JavaPlugin {
 
     private ConfigManager configManager;
+    private DatabaseManager databaseManager;
+    private PlayerCache playerCache;
 
     @Override
     public void onEnable() {
         this.configManager = new ConfigManager(this);
         this.configManager.loadConfigs();
+
+        try {
+            this.databaseManager = new DatabaseManager(this);
+            this.playerCache = new PlayerCache(databaseManager);
+        } catch (Exception e) {
+            getLogger().severe("Unable to initialise database: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        PluginManager pm = getServer().getPluginManager();
+        pm.registerEvents(new PlayerListener(playerCache), this);
+
         this.getLogger().info("Faskin plugin enabled");
     }
 
     @Override
     public void onDisable() {
+        if (playerCache != null) {
+            playerCache.saveAll();
+        }
+        if (databaseManager != null) {
+            databaseManager.close();
+        }
         this.getLogger().info("Faskin plugin disabled");
     }
 
     public ConfigManager getConfigManager() {
         return configManager;
+    }
+
+    public DatabaseManager getDatabaseManager() {
+        return databaseManager;
+    }
+
+    public PlayerCache getPlayerCache() {
+        return playerCache;
     }
 }

--- a/src/main/java/fr/projetserveur/faskin/cache/PlayerCache.java
+++ b/src/main/java/fr/projetserveur/faskin/cache/PlayerCache.java
@@ -1,0 +1,54 @@
+package fr.projetserveur.faskin.cache;
+
+import fr.projetserveur.faskin.database.PlayerData;
+import fr.projetserveur.faskin.managers.DatabaseManager;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Simple in-memory cache for player data.
+ */
+public class PlayerCache {
+
+    private final Map<UUID, PlayerData> cache = new HashMap<>();
+    private final DatabaseManager databaseManager;
+
+    public PlayerCache(DatabaseManager databaseManager) {
+        this.databaseManager = databaseManager;
+    }
+
+    public PlayerData get(UUID uuid) {
+        return cache.get(uuid);
+    }
+
+    public void handleJoin(Player player) {
+        UUID uuid = player.getUniqueId();
+        PlayerData data = databaseManager.loadPlayerData(uuid);
+        if (data == null) {
+            data = new PlayerData(uuid, player.getName(), "", false,
+                    player.getAddress() != null ? player.getAddress().getAddress().getHostAddress() : "");
+        } else {
+            data.setUsername(player.getName());
+            data.setLastIpAddress(player.getAddress() != null ? player.getAddress().getAddress().getHostAddress() : "");
+        }
+        cache.put(uuid, data);
+    }
+
+    public void handleQuit(Player player) {
+        UUID uuid = player.getUniqueId();
+        PlayerData data = cache.remove(uuid);
+        if (data != null) {
+            databaseManager.savePlayerData(data);
+        }
+    }
+
+    public void saveAll() {
+        for (PlayerData data : cache.values()) {
+            databaseManager.savePlayerData(data);
+        }
+        cache.clear();
+    }
+}

--- a/src/main/java/fr/projetserveur/faskin/database/IDatabase.java
+++ b/src/main/java/fr/projetserveur/faskin/database/IDatabase.java
@@ -1,0 +1,21 @@
+package fr.projetserveur.faskin.database;
+
+import java.util.UUID;
+
+public interface IDatabase {
+
+    /**
+     * Loads player data from storage.
+     *
+     * @param uniqueId player's unique identifier
+     * @return loaded player data or null if absent
+     */
+    PlayerData loadPlayerData(UUID uniqueId);
+
+    /**
+     * Saves player data to storage.
+     *
+     * @param data player data to persist
+     */
+    void savePlayerData(PlayerData data);
+}

--- a/src/main/java/fr/projetserveur/faskin/database/PlayerData.java
+++ b/src/main/java/fr/projetserveur/faskin/database/PlayerData.java
@@ -1,0 +1,59 @@
+package fr.projetserveur.faskin.database;
+
+import java.util.UUID;
+
+/**
+ * Represents persistent data for a player.
+ */
+public class PlayerData {
+
+    private final UUID uniqueId;
+    private String username;
+    private String passwordHash;
+    private boolean isPremium;
+    private String lastIpAddress;
+
+    public PlayerData(UUID uniqueId, String username, String passwordHash, boolean isPremium, String lastIpAddress) {
+        this.uniqueId = uniqueId;
+        this.username = username;
+        this.passwordHash = passwordHash;
+        this.isPremium = isPremium;
+        this.lastIpAddress = lastIpAddress;
+    }
+
+    public UUID getUniqueId() {
+        return uniqueId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public boolean isPremium() {
+        return isPremium;
+    }
+
+    public void setPremium(boolean premium) {
+        isPremium = premium;
+    }
+
+    public String getLastIpAddress() {
+        return lastIpAddress;
+    }
+
+    public void setLastIpAddress(String lastIpAddress) {
+        this.lastIpAddress = lastIpAddress;
+    }
+}

--- a/src/main/java/fr/projetserveur/faskin/database/SQLiteDatabase.java
+++ b/src/main/java/fr/projetserveur/faskin/database/SQLiteDatabase.java
@@ -1,0 +1,83 @@
+package fr.projetserveur.faskin.database;
+
+import java.io.File;
+import java.sql.*;
+import java.util.UUID;
+
+/**
+ * SQLite implementation of the IDatabase interface.
+ */
+public class SQLiteDatabase implements IDatabase {
+
+    private final Connection connection;
+
+    public SQLiteDatabase(File dataFolder) throws SQLException {
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+        File dbFile = new File(dataFolder, "database.db");
+        String url = "jdbc:sqlite:" + dbFile.getPath();
+        this.connection = DriverManager.getConnection(url);
+        createTable();
+    }
+
+    private void createTable() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS players (" +
+                "unique_id TEXT PRIMARY KEY, " +
+                "username TEXT NOT NULL, " +
+                "password_hash TEXT NOT NULL, " +
+                "is_premium INTEGER NOT NULL, " +
+                "last_ip TEXT" +
+                ")";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+
+    @Override
+    public PlayerData loadPlayerData(UUID uniqueId) {
+        String sql = "SELECT username, password_hash, is_premium, last_ip FROM players WHERE unique_id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, uniqueId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    String username = rs.getString("username");
+                    String passwordHash = rs.getString("password_hash");
+                    boolean isPremium = rs.getInt("is_premium") == 1;
+                    String lastIp = rs.getString("last_ip");
+                    return new PlayerData(uniqueId, username, passwordHash, isPremium, lastIp);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public void savePlayerData(PlayerData data) {
+        String sql = "INSERT INTO players (unique_id, username, password_hash, is_premium, last_ip) " +
+                "VALUES (?, ?, ?, ?, ?) " +
+                "ON CONFLICT(unique_id) DO UPDATE SET " +
+                "username=excluded.username, password_hash=excluded.password_hash, " +
+                "is_premium=excluded.is_premium, last_ip=excluded.last_ip";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, data.getUniqueId().toString());
+            ps.setString(2, data.getUsername());
+            ps.setString(3, data.getPasswordHash());
+            ps.setInt(4, data.isPremium() ? 1 : 0);
+            ps.setString(5, data.getLastIpAddress());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void close() {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/fr/projetserveur/faskin/listeners/PlayerListener.java
+++ b/src/main/java/fr/projetserveur/faskin/listeners/PlayerListener.java
@@ -1,0 +1,29 @@
+package fr.projetserveur.faskin.listeners;
+
+import fr.projetserveur.faskin.cache.PlayerCache;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles basic player join and quit events to manage the cache lifecycle.
+ */
+public class PlayerListener implements Listener {
+
+    private final PlayerCache playerCache;
+
+    public PlayerListener(PlayerCache playerCache) {
+        this.playerCache = playerCache;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        playerCache.handleJoin(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        playerCache.handleQuit(event.getPlayer());
+    }
+}

--- a/src/main/java/fr/projetserveur/faskin/managers/DatabaseManager.java
+++ b/src/main/java/fr/projetserveur/faskin/managers/DatabaseManager.java
@@ -1,0 +1,35 @@
+package fr.projetserveur.faskin.managers;
+
+import fr.projetserveur.faskin.database.IDatabase;
+import fr.projetserveur.faskin.database.PlayerData;
+import fr.projetserveur.faskin.database.SQLiteDatabase;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+/**
+ * Central access point to the chosen database implementation.
+ */
+public class DatabaseManager {
+
+    private final IDatabase database;
+
+    public DatabaseManager(JavaPlugin plugin) throws SQLException {
+        this.database = new SQLiteDatabase(plugin.getDataFolder());
+    }
+
+    public PlayerData loadPlayerData(UUID uniqueId) {
+        return database.loadPlayerData(uniqueId);
+    }
+
+    public void savePlayerData(PlayerData data) {
+        database.savePlayerData(data);
+    }
+
+    public void close() {
+        if (database instanceof SQLiteDatabase sqlite) {
+            sqlite.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SQLite-based persistence layer for player data
- manage player cache and lifecycle events
- document new core functionality and roadmap progress

## Testing
- `mvn -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a327b77734832485fd91e77f689afe