### PR TITLE
chore: remove ProtocolLib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.comphenix.protocol</groupId>
-            <artifactId>ProtocolLib</artifactId>
-            <version>5.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
             <version>0.10.2</version>


### PR DESCRIPTION
## Summary
- remove ProtocolLib from Maven dependencies

## Testing
- `mvn -e -ntp test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a37b2fa7dc83248f41db0a5d52d59c