### PR TITLE
feat: add MySQL connection and clean build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/monprojet/faskin/Faskin.java
+++ b/src/main/java/com/monprojet/faskin/Faskin.java
@@ -1,19 +1,29 @@
 package com.monprojet.faskin;
 
+import com.monprojet.faskin.database.MySQLManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class Faskin extends JavaPlugin {
 
+    private MySQLManager mySQLManager;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
-        getLogger().info("Faskin a été activé. En attente de la logique d'initialisation...");
-        getLogger().info("Ce plugin nécessite ProtocolLib pour fonctionner correctement.");
+        // Créer le fichier config.yml par défaut s'il n'existe pas
+        saveDefaultConfig();
+
+        // Initialiser et connecter à la base de données
+        this.mySQLManager = new MySQLManager(this);
+        this.mySQLManager.connect();
+
+        getLogger().info("Faskin a été activé.");
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
-        getLogger().info("Faskin a été désactivé. En attente de la logique de nettoyage...");
+        if (this.mySQLManager != null) {
+            this.mySQLManager.disconnect();
+        }
+        getLogger().info("Faskin a été désactivé.");
     }
 }

--- a/src/main/java/com/monprojet/faskin/database/MySQLManager.java
+++ b/src/main/java/com/monprojet/faskin/database/MySQLManager.java
@@ -1,0 +1,58 @@
+package com.monprojet.faskin.database;
+
+import com.monprojet.faskin.Faskin;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class MySQLManager {
+
+    private final Faskin plugin;
+    private Connection connection;
+
+    public MySQLManager(Faskin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void connect() {
+        FileConfiguration config = plugin.getConfig();
+        String host = config.getString("database.host");
+        int port = config.getInt("database.port");
+        String dbName = config.getString("database.database");
+        String user = config.getString("database.username");
+        String pass = config.getString("database.password");
+
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return;
+            }
+
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            this.connection = DriverManager.getConnection(
+                "jdbc:mysql://" + host + ":" + port + "/" + dbName + "?autoReconnect=true",
+                user,
+                pass
+            );
+
+            plugin.getLogger().info("Connexion à la base de données MySQL établie avec succès !");
+
+        } catch (SQLException | ClassNotFoundException e) {
+            plugin.getLogger().severe("Impossible de se connecter à la base de données MySQL !");
+            e.printStackTrace();
+        }
+    }
+
+    public void disconnect() {
+        if (connection != null) {
+            try {
+                connection.close();
+                plugin.getLogger().info("Déconnexion de la base de données MySQL.");
+            } catch (SQLException e) {
+                plugin.getLogger().severe("Erreur lors de la déconnexion de la base de données.");
+                e.printStackTrace();
+            }
+        }
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,8 @@
+# Configuration de la base de données pour Faskin
+database:
+  host: "51.75.125.229"
+  port: 3306
+  database: "faskin_data"
+  username: "root"
+  password: "CHANGER_MOT_DE_PASSE"
+


### PR DESCRIPTION
## Summary
- initialize database manager and connect using MySQL
- add default config for database settings
- fix shade plugin warnings by merging service resources

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a38001b61c83249e2da130b9b5d34e