### PR TITLE
chore: remove bcrypt compile dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>at.favre.lib</groupId>
-            <artifactId>bcrypt</artifactId>
-            <version>0.10.2</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.0.33</version>


### PR DESCRIPTION
## Summary
- remove at.favre.lib:bcrypt from the build configuration

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_68a38d4cf78083248fc2e4ff35898118