### PR TITLE
fix: reintroduce bcrypt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,5 +85,11 @@
             <version>3.45.1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>0.10.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- re-add bcrypt library for local compilation

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a38fb6be54832483bf2f7eb8750328