### PR TITLE
fix: shade dependencies for runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,26 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <relocation>
+                                    <pattern>at.favre.lib.bcrypt</pattern>
+                                    <shadedPattern>com.monprojet.faskin.shaded.bcrypt</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>at.favre.lib.bytes</pattern>
+                                    <shadedPattern>com.monprojet.faskin.shaded.bytes</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
@@ -77,7 +97,7 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.0.33</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>


### PR DESCRIPTION
## Summary
- configure maven-shade-plugin to bundle and relocate BCrypt and Bytes libs
- include MySQL connector and other libraries with compile scope to prevent missing classes

## Testing
- `xmllint --noout pom.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a3999240b4832486d938e787ad4031